### PR TITLE
Feat/luakittens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !TODO.md
 
 # Collaborators consistency
+!.luarc.json
 !.editorconfig
 !stylua.toml
 !.pre-commit-config.yaml

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,31 @@
+{
+  "Lua": {
+    "diagnostics": {
+			"unusedLocalExclude": [ "_*" ]
+    },
+    "globals": [
+      "vim"
+    ],
+    "workspace": {
+    	"checkThirdParty": false,
+      "ignoreDir": [
+        ".git",
+        ".github",
+        ".direnv",
+        "result",
+        "nix",
+        "doc",
+				"docs"
+      ],
+      "library": [
+				"lua",
+				"$VIMRUNTIME",
+        "${3rd}/busted/library",
+        "${3rd}/luassert/library"
+      ]
+    }
+  },
+  "runtime": {
+    "version": "LuaJIT"
+  }
+}

--- a/lua/cpp-tools/lib/fp/init.lua
+++ b/lua/cpp-tools/lib/fp/init.lua
@@ -161,6 +161,7 @@ function M.fmt(str)
 	end
 end
 
+---@package
 function M.__test()
 	describe('`flip()`', function()
 		it('Flips a two arg function', function()

--- a/lua/cpp-tools/lib/fp/init.lua
+++ b/lua/cpp-tools/lib/fp/init.lua
@@ -1,0 +1,236 @@
+local M = {}
+
+---Takes a function of two arguments and flips their parameters
+---@generic T, U
+---@param fun fun(lhs: `T`, rhs: `U`): any Function to flip
+---@return fun(rhs: U, lhs: `T`): any # Flipped function
+function M.flip(fun)
+	return function(lhs, rhs)
+		return fun(rhs, lhs)
+	end
+end
+
+---Partially applies some function arguments
+---@param fun fun(...: any): any Function to apply args to
+---@param ... any Args to apply
+---@return fun(...: any): any # Function with args applied
+function M.partial(fun, ...)
+	local passed = { ... }
+	return function(...)
+		return fun(unpack(vim.list_extend(passed, { ... })))
+	end
+end
+
+---Partially applies some function arguments to the back
+---@param fun fun(...: any): any Function to apply args to
+---@param ... any Args to apply
+---@return fun(...: any): any # Function with args applied to the back
+function M.partial_(fun, ...)
+	local passed = { ... }
+	return function(...)
+		return fun(unpack(vim.list_extend({ ... }, passed)))
+	end
+end
+
+---Returns the nth argument passed to this function
+---@param n number Which argument to return
+---@param ... any Args
+---@return any # Nth arg
+function M.nth(n, ...)
+	return ({ ... })[n]
+end
+
+---Returns the first argument passed to this function
+---@generic T
+---@param a `T` The first arg
+---@return T # The first argument
+function M.first(a)
+	return a
+end
+
+---Returns the second argument passed to this function
+---@generic T
+---@param _a any First arg, discarded
+---@param b `T` Second arg, returned
+---@return T # Second arg
+function M.second(_a, b)
+	return b
+end
+
+---Returns a function that compares its argument to `value`
+---@generic T
+---@param value `T` Value to compare against
+---@return fun(x: T): boolean
+function M.equal(value)
+	return function(x)
+		return x == value
+	end
+end
+
+---If it's a function, calls it, otherwise returns id
+---@generic R, V
+---@param value fun(any...): `R`|V Value to call/return
+---@param ... any Possible values to pass to the function
+---@return R|V
+function M.eval(value, ...)
+	if type(value) == 'function' then
+		return value(...)
+	else
+		return value
+	end
+end
+
+---Returns the result of a function wrapped in an array
+---@generic Ts
+---@param f fun(any...): `Ts` Function to wrap
+---@return fun(...): [Ts]
+function M.arraified(f)
+	return function(...)
+		return { f(...) }
+	end
+end
+
+---Returns the args untouched
+---@param ... any Args to return
+---@return ... any
+function M.id(...)
+	return ...
+end
+
+---Returns `id` or the passed in function
+---@generic Rs, Ts
+---@param value fun(...: `Ts`): `Rs`|nil Value to call/return
+---@return fun(...: Ts): `Rs`|fun(...: any): ...
+function M.maybe_fn(value)
+	assert(type(value) == 'function' or value == nil)
+
+	if type(value) == 'function' then
+		return value
+	else
+		return M.id
+	end
+end
+
+---Reduces the result over a function
+---@generic T, U, R
+---@param f fun(arg1: T, arg2: U): `R` The applied function
+---@param acc R The accumulator and initial value
+---@return R
+function M.foldl(f, acc, ...)
+	if select('#', ...) == 0 then
+		return acc
+	end
+	local l = ...
+	return M.foldl(f, f(acc, l), select(2, ...))
+end
+
+---Composes two functions f, g and into `g(f(...))`
+---@generic FirstR, SecondR
+---@param f fun(...: any): `FirstR`
+---@param g fun(...: FirstR): `SecondR`
+---@return fun(...: any): SecondR
+function M.compose(f, g)
+	return function(...)
+		return g(f(...))
+	end
+end
+
+---Chains several functions invocations together
+---chain(a, b, c) results in c(b(a(...)))
+---@param ... fun(...: any): ...
+---@return fun(...: any): ...
+function M.chain(...)
+	return M.foldl(M.compose, M.id, ...)
+end
+
+---Returns `not f(...)`
+---@param f fun(...: any): boolean func to inverse
+---@return fun(...: any): boolean
+function M.nah(f)
+	return function(...)
+		return not f(...)
+	end
+end
+
+---Formats the arguments
+---@param str string The format string
+---@return fun(...: any): string
+function M.fmt(str)
+	return function(...)
+		return str:format(...)
+	end
+end
+
+function M.__test()
+	describe('`flip()`', function()
+		it('Flips a two arg function', function()
+			local sub = function(a, b)
+				return a - b
+			end
+
+			assert.are.same(sub(5, 3), 2)
+			assert.are.same(M.flip(sub)(5, 3), -2)
+		end)
+
+		it('Makes a one arg function accept only the second argument', function()
+			assert.are.same(M.id(5), 5)
+			assert.are.same(M.flip(M.id)(5, 3), 3)
+		end)
+	end)
+
+	describe('`partial()`', function()
+		it('Applies the first argument', function()
+			local sub = function(a, b)
+				return a - b
+			end
+
+			assert.are.same(M.partial(sub, 5)(3), 2)
+		end)
+
+		it('Applies all arguments', function()
+			local sub = function(a, b)
+				return a - b
+			end
+
+			assert.are.same(M.partial(sub, 5, 3)(), 2)
+		end)
+	end)
+
+	describe('`partial_()`', function()
+		it('Applies the last argument', function()
+			local sub = function(a, b)
+				return a - b
+			end
+
+			assert.are.same(M.partial_(sub, 5)(3), -2)
+		end)
+
+		it('Applies all arguments', function()
+			local sub = function(a, b)
+				return a - b
+			end
+
+			assert.are.same(M.partial_(sub, 5, 3)(), 2)
+		end)
+	end)
+
+	describe('`partial_()`', function()
+		it('Applies the last argument', function()
+			local sub = function(a, b)
+				return a - b
+			end
+
+			assert.are.same(M.partial_(sub, 5)(3), -2)
+		end)
+
+		it('Applies all arguments', function()
+			local sub = function(a, b)
+				return a - b
+			end
+
+			assert.are.same(M.partial_(sub, 5, 3)(), 2)
+		end)
+	end)
+end
+
+return M

--- a/lua/cpp-tools/lib/iter/init.lua
+++ b/lua/cpp-tools/lib/iter/init.lua
@@ -62,6 +62,7 @@ function M.partition(range, pred, proj_beg)
 		vim.iter(range):map(proj_beg):filter(fp.nah(pred)):totable() or {}
 end
 
+---@package
 function M.__test()
 	describe('`array_equals()`', function()
 		it('Two same references to empty are equal', function()

--- a/lua/cpp-tools/lib/iter/init.lua
+++ b/lua/cpp-tools/lib/iter/init.lua
@@ -49,63 +49,59 @@ function M.arrays_equal(arr1, arr2)
 end
 
 function M.__test()
-	describe('array_equals', function()
-		local iter = require('lua.cpp-tools.lib.iter.init')
-
+	describe('`array_equals()`', function()
 		it('Two same references to empty are equal', function()
 			local empty = {}
 			local a = empty
 			local b = empty
 
-			assert.is.truthy(iter.arrays_equal(a, b))
+			assert.is.truthy(M.arrays_equal(a, b))
 		end)
 
 		it('Two different references to empty are equal', function()
 			local a = {}
 			local b = {}
 
-			assert.is.truthy(iter.arrays_equal(a, b))
+			assert.is.truthy(M.arrays_equal(a, b))
 		end)
 
 		it('Two same values are equal', function()
 			local a = { 1, 2 }
 			local b = { 1, 2 }
 
-			assert.is.truthy(iter.arrays_equal(a, b))
+			assert.is.truthy(M.arrays_equal(a, b))
 		end)
 
 		it('Two same values with different order are not equal', function()
 			local a = { 1, 2 }
 			local b = { 2, 1 }
 
-			assert.is.falsy(iter.arrays_equal(a, b))
+			assert.is.falsy(M.arrays_equal(a, b))
 		end)
 
 		it('Two same values with different values', function()
 			local a = { '' }
 			local b = { 1 }
 
-			assert.is.falsy(iter.arrays_equal(a, b))
+			assert.is.falsy(M.arrays_equal(a, b))
 		end)
 	end)
 
-	describe('line_count', function()
-		local iter = require('lua.cpp-tools.lib.iter.init')
-
+	describe('`line_count()`', function()
 		it('Returns 1 for an empty string', function()
-			assert.are.equal(iter.line_count(''), 1)
+			assert.are.equal(M.line_count(''), 1)
 		end)
 
 		it('Returns 1 for a non empty string with one line', function()
-			assert.are.equal(iter.line_count('Hello there'), 1)
+			assert.are.equal(M.line_count('Hello there'), 1)
 		end)
 
 		it('Returns 1 for a string with a trailing newlien', function()
-			assert.are.equal(iter.line_count('Foo\n'), 1)
+			assert.are.equal(M.line_count('Foo\n'), 1)
 		end)
 
 		it('Returns 2 for a string with a trailing newline and content after it', function()
-			assert.are.equal(iter.line_count('Foo\nBar'), 2)
+			assert.are.equal(M.line_count('Foo\nBar'), 2)
 		end)
 
 		it('Returns X for a string with X lines (ignoring last newline)', function()
@@ -114,16 +110,14 @@ function M.__test()
 			second line
 			third line]]
 
-			assert.are.equal(iter.line_count(three_lined_string), 3)
+			assert.are.equal(M.line_count(three_lined_string), 3)
 		end)
 	end)
 
-	describe('lines', function()
-		local iter = require('lua.cpp-tools.lib.iter.init')
-
+	describe('`lines()`', function()
 		it('Returns one empty line untouched', function()
 			local empty_line = ''
-			local lines = iter.lines(empty_line)
+			local lines = M.lines(empty_line)
 
 			assert.are.equal(#lines, 1)
 			assert.are.equal(lines[1], empty_line)
@@ -131,7 +125,7 @@ function M.__test()
 
 		it('Returns one non empty line untouched', function()
 			local empty_line = 'asdasdasdasdasd'
-			local lines = iter.lines(empty_line)
+			local lines = M.lines(empty_line)
 
 			assert.are.equal(#lines, 1)
 			assert.are.equal(lines[1], empty_line)
@@ -141,7 +135,7 @@ function M.__test()
 			local lines_arr = { 'line1', 'line2', 'line3' }
 			local lines_str = vim.fn.join(lines_arr, '\n')
 
-			assert.is.truthy(iter.arrays_equal(iter.lines(lines_str), lines_arr))
+			assert.is.truthy(M.arrays_equal(M.lines(lines_str), lines_arr))
 		end)
 	end)
 end

--- a/lua/cpp-tools/lib/iter/init.lua
+++ b/lua/cpp-tools/lib/iter/init.lua
@@ -48,6 +48,20 @@ function M.arrays_equal(arr1, arr2)
 	return true
 end
 
+---Partitions the given range into one satisfying the pred and one not satisfying the pred
+---@generic T
+---@param range [`T`] The range to partition
+---@param pred fun(T): boolean The predicate by which to partition
+---@return [T] # [T] satisfying the predicate
+---@return [T] # [T] not satisfying the predicate
+function M.partition(range, pred, proj_beg)
+	local fp = require('cpp-tools.lib.fp')
+	proj_beg = fp.maybe_fn(proj_beg)
+
+	return vim.iter(range):map(proj_beg):filter(pred):totable() or {},
+		vim.iter(range):map(proj_beg):filter(fp.nah(pred)):totable() or {}
+end
+
 function M.__test()
 	describe('`array_equals()`', function()
 		it('Two same references to empty are equal', function()
@@ -136,6 +150,50 @@ function M.__test()
 			local lines_str = vim.fn.join(lines_arr, '\n')
 
 			assert.is.truthy(M.arrays_equal(M.lines(lines_str), lines_arr))
+		end)
+	end)
+
+	describe('`partition()`', function()
+		it('Partitions all left', function()
+			local arr = { 1, 2, 3, 4, 5, 6, 7, 8 }
+			local good, bad = M.partition(arr, function()
+				return true
+			end)
+
+			assert.are.same(good, arr)
+			assert.are.same(bad, {})
+		end)
+
+		it('Partitions all right', function()
+			local arr = { 1, 2, 3, 4, 5, 6, 7, 8 }
+			local good, bad = M.partition(arr, function()
+				return false
+			end)
+
+			assert.are.same(good, {})
+			assert.are.same(bad, arr)
+		end)
+
+		it('Partitions both sides', function()
+			local arr = { 1, 2, 3, 4, 5, 6, 7, 8 }
+			local good, bad = M.partition(arr, function(n)
+				return n % 2 == 0
+			end)
+
+			assert.are.same(good, { 2, 4, 6, 8 })
+			assert.are.same(bad, { 1, 3, 5, 7 })
+		end)
+
+		it('Applies the projection properly', function()
+			local arr = { 1, 2, 3, 4, 5, 6, 7, 8 }
+			local good, bad = M.partition(arr, function(n)
+				return n < 10
+			end, function(n)
+				return n * 2
+			end)
+
+			assert.are.same(good, { 2, 4, 6, 8 })
+			assert.are.same(bad, { 10, 12, 14, 16 })
 		end)
 	end)
 end

--- a/lua/cpp-tools/lib/luakittens/init.lua
+++ b/lua/cpp-tools/lib/luakittens/init.lua
@@ -1,0 +1,246 @@
+local M = {}
+
+--[[
+1. Parse
+2. Remove grammar duplicates
+3. Rewrite some grammar
+	- `nil|foo` -> `foo?`
+	- `a|b|c|any` -> `any`
+	- `opt = '?'` -> `opt = true`
+3.
+]]
+
+--------------------------------------------------
+-- Types
+--------------------------------------------------
+
+---@alias cpp-tools.luakittens.Kitten string
+
+---@package
+---@enum cpp-tools.luakittens.TypeKind
+local TypeKind = {
+	Fundamental = 'fundamental',
+	Array = 'array',
+	Dict = 'dict',
+	Table = 'table',
+	Tuple = 'tuple',
+}
+
+---@package
+---@enum cpp-tools.luakittens.Typename
+local Typename = {
+	Nil = 'nil',
+	Any = 'any',
+	String = 'string',
+	Number = 'number',
+	Table = 'table',
+	Fn = 'fn',
+	Bool = 'bool',
+}
+
+---@class cpp-tools.luakittens.AnyType
+---@field [1] cpp-tools.luakittens.Array|cpp-tools.luakittens.Fundamental|cpp-tools.luakittens.Table|cpp-tools.luakittens.Tuple|cpp-tools.luakittens.Dict
+
+---@class (exact) cpp-tools.luakittens.Type : cpp-tools.luakittens.AnyType
+---@field opt string?
+
+---@class (exact) cpp-tools.luakittens.Fundamental
+---@field kind cpp-tools.luakittens.TypeKind.Fundamental The kind of the type
+---@field type cpp-tools.luakittens.Typename The exact type, this includes all basic lua types except thread, userdata and `boolean` is changed to `bool`
+
+---@class (exact) cpp-tools.luakittens.Array
+---@field kind cpp-tools.luakittens.TypeKind.Array
+---@field type cpp-tools.luakittens.Type
+
+---@class (exact) cpp-tools.luakittens.TableElem
+---@field key string
+---@field val cpp-tools.luakittens.Type
+
+---@class (exact) cpp-tools.luakittens.Table
+---@field kind cpp-tools.luakittens.TypeKind.Table
+---@field fields cpp-tools.luakittens.TableElem[]
+
+---@class (exact) cpp-tools.luakittens.Tuple
+---@field kind cpp-tools.luakittens.TypeKind.Tuple
+---@field types cpp-tools.luakittens.TableElem[]
+
+---@class (exact) cpp-tools.luakittens.Dict
+---@field kind cpp-tools.luakittens.TypeKind.Dict
+---@field key cpp-tools.luakittens.Type
+---@field val cpp-tools.luakittens.Type
+---@field opt string?
+
+--------------------------------------------------
+-- End Types
+--------------------------------------------------
+
+---Parses a type annotation with a grammar similar to that of luaCATS - luaKITTENS
+---
+---The differences are:
+---	- only `nil`, `any`, `string`, `number`, (`function`/`fn`), (`boolean`/`bool`), `table` fundamental types are supported
+--- - no support for function types (only `function` or `fn` are allowed)
+--- - booleans can be typed both as `bool` and `boolean`
+--- - arrays use the `[]type` syntax instead of `type[]`
+--- - tuples use `()` instead of `[]`
+--- - the key-value table syntax (`table<T, U>`) is not supported, instead only the dict version exists - `{ [T]: U }`
+--- - the syntax is more restrictive, the following things are not allowed, because they're illogical:
+--- 	- `nil?` - an optional type already means `T|nil`, `nil|nil` doesn't make sense
+--- 	- `T|U|T|...` - the syntax disallows specifying the same type twice ( TODO:)
+---
+---@param kitty cpp-tools.luakittens.Kitten a luaKITTEN definition
+---@return boolean, string|cpp-tools.luakittens.Type[]
+function M.parse(kitty)
+	-- TODO: It doesn't make sense to have an optional nil, make it impossible to make in grammar
+	-- TODO: Make trailing commas allowed
+
+	local grammar = [==[
+    grammar <- ws alternative_type ws eof
+
+    alternative_type <- any_type (ws '|' ws alternative_type )*
+
+    any_type <- {| array_type / dict_type / table_type / tuple_type / fundamental_type opt? |}
+
+    tuple_type <- '(' ws {:types: {| tuple_elem (ws ',' ws tuple_elem)* |} :} ws {:kind: ')' -> 'tuple' :}
+    tuple_elem <- any_type
+
+    dict_type <- '{' ws dict_key ws ':' ws dict_val ws  {:kind: '}' -> 'dict' :}
+    dict_key <- {:key: '[' ws any_type ws ']' :}
+    dict_val <- {:val: any_type :}
+
+    table_type <- '{' ws {:fields: {| table_elem (ws ',' ws table_elem)* |} :} ws {:kind: '}' -> 'table' :}
+    table_elem <- {| {:key: ident :} ws ':' ws {:val: any_type :} |}
+
+    array_type <-  {:kind: '[]' -> 'array' :} {:type: any_type :}
+
+    fundamental_type <- {:type: typename :} {:kind: '' -> 'fundamental' :}
+
+    typename <- 'nil' / 'any' / 'string' / 'number' / 'table' / function_typename / boolean_typename
+    boolean_typename <- {~ ('boolean' / 'bool') -> 'bool' ~}
+    function_typename <- {~ ('function' / 'fn') -> 'fn' ~}
+
+    opt <- {:opt: '?' :}
+
+    ident <- escaped_ident / basic_ident
+
+    basic_ident <- [a-zA-Z_][a-zA-Z0-9_]*
+    escaped_ident <- {:used_quote: quote :} { (!(=used_quote) .)+ } =used_quote
+
+    quote <- "'" / '"'
+
+    eof <- !.
+    ws <- %s*
+  ]==]
+
+	local pattern = vim.re.compile(grammar)
+
+	local matches = pattern:match(kitty)
+
+	if not matches then
+		return false, 'Cannot parse kitty\'s grammar.'
+	end
+
+	return true, matches --[=[@as cpp-tools.luakittens.Type[] ]=]
+end
+
+---@package
+function M.__test()
+	assert:set_parameter('TableFormatLevel', 10)
+
+	local fp = require('cpp-tools.lib.fp')
+	local parse = fp.chain(M.parse, fp.second)
+
+	local fund = function(t)
+		return { kind = 'fundamental', type = t }
+	end
+	local arr = function(t)
+		return { kind = 'array', type = t }
+	end
+	local tup = function(...)
+		return { kind = 'tuple', types = { ... } }
+	end
+	local dict = function(k, v)
+		return { kind = 'dict', key = k, val = v }
+	end
+	local field = function(k, v)
+		return { key = k, val = v }
+	end
+
+	describe('`parse()`', function()
+		it('Parses single fundamental types', function()
+			assert.is.falsy(M.parse('foo'))
+
+			assert.are.same(fund('string'), parse('string'))
+			assert.are.same(fund('number'), parse('number'))
+			assert.are.same(fund('nil'), parse('nil'))
+			assert.are.same(fund('any'), parse('any'))
+
+			assert.are.same(fund('fn'), parse('fn'))
+			assert.are.same(fund('fn'), parse('function'))
+			assert.are.same(fund('bool'), parse('bool'))
+			assert.are.same(fund('bool'), parse('boolean'))
+		end)
+
+		it('Parses arrays', function()
+			assert.are.same(arr(fund('string')), parse('[]string'))
+
+			assert.are.same(arr(arr(fund('string'))), parse('[][]string'))
+
+			assert.is.falsy(M.parse('string[]'))
+		end)
+
+		it('Parses tuples', function()
+			assert.are.same(tup(fund('string')), parse('(string)'))
+
+			assert.are.same(tup(fund('string'), fund('number')), parse('(string, number)'))
+
+			assert.are.same(
+				tup(fund('string'), arr(fund('number')), tup(arr(tup(fund('fn'))), fund('bool'))),
+				parse('(string, []number, ([](fn), bool))')
+			)
+		end)
+
+		it('Parses dicts', function()
+			assert.are.same(dict(fund('string'), fund('fn')), parse('{ [string]: fn }'))
+
+			assert.are.same(
+				dict(
+					dict(fund('string'), arr(fund('fn'))),
+					tup(dict(fund('bool'), fund('bool')), arr(dict(fund('fn'), fund('fn'))))
+				),
+				parse([=[
+				{
+					[{ [string]: []fn }]:
+					({ [bool]: bool }, []{ [fn]: fn })
+				}
+				]=])
+			)
+		end)
+
+		it('Parses tables', function()
+			assert.are.same({
+				kind = 'table',
+				fields = {
+					field('foo', fund('fn')),
+				},
+			}, parse('{ foo: fn }'))
+
+			assert.are.same(
+				{
+					kind = 'table',
+					fields = {
+						field('siema n k o ', fund('fn')),
+						field('{ "siema n k o ": fn }', arr(fund('bool'))),
+					},
+				},
+				parse([[
+				{
+					"siema n k o ": fn,
+					'{ "siema n k o ": fn }': []bool
+				}
+				]])
+			)
+		end)
+	end)
+end
+
+return M

--- a/lua/cpp-tools/lib/luakittens/parser.lua
+++ b/lua/cpp-tools/lib/luakittens/parser.lua
@@ -4,6 +4,17 @@ local M = {}
 -- Types
 --------------------------------------------------
 
+--[[
+
+This is a very basic implementation, but I will rewrite the parsing to use a handwritten parser
+because the lpeg re implementation isn't sufficient and doesn't allow for any remotely useful diagnostics.
+
+The current implementation lacks the ability to express alternative types in complex types.
+The blocker is that with this lpeg parser it's impossible to not make things like `[]string|number` ambiguous
+(this gets parsed as `[](string|number)`).
+
+]]
+
 ---@alias cpp-tools.luakittens.Kitten string
 
 ---@package

--- a/lua/cpp-tools/lib/luakittens/parser.lua
+++ b/lua/cpp-tools/lib/luakittens/parser.lua
@@ -289,7 +289,7 @@ function M.__test()
 	local fp = require('cpp-tools.lib.fp')
 	local parse = fp.chain(only_parse, fp.second)
 
-	describe('`parse()`', function()
+	describe('`only_parse()`', function()
 		it('Parses single fundamental types', function()
 			assert.is.falsy(only_parse('foo'))
 

--- a/lua/cpp-tools/lib/luakittens/parser.lua
+++ b/lua/cpp-tools/lib/luakittens/parser.lua
@@ -198,7 +198,6 @@ end
 --- - the key-value table syntax (`table<T, U>`) is not supported, instead only the dict version exists - `{ [T]: U }`
 --- - the syntax is more restrictive, the following things are not allowed:
 --- 	- `nil?` - an optional type already means `T|nil`, `nil|nil` doesn't make sense
---- 	- TODO: specifying `nil` as a key to a table/dict - in lua that means deleting a key from a table
 ---
 ---@param kitty cpp-tools.luakittens.Kitten a luaKITTEN definition
 ---@return boolean, string|cpp-tools.luakittens.Matches
@@ -403,6 +402,14 @@ function M.__test()
 				{ fund('nil'), arr(fund('string')), tuple(fund('string'), fund('number')) },
 				parse('nil|[]string|(string, number)')
 			)
+		end)
+
+		it('Nil is prohibited in dict', function()
+			assert.are.falsy(only_parse('{ [string]: nil }'))
+		end)
+
+		it('Nil is prohibited in table', function()
+			assert.are.falsy(only_parse('{ foo: nil }'))
 		end)
 	end)
 

--- a/lua/cpp-tools/lib/luakittens/parser.lua
+++ b/lua/cpp-tools/lib/luakittens/parser.lua
@@ -38,15 +38,22 @@ local Typename = {
 	Bool = 'bool',
 }
 
----@class cpp-tools.luakittens.AnyType
----@field [1] cpp-tools.luakittens.Array|cpp-tools.luakittens.Fundamental|cpp-tools.luakittens.Table|cpp-tools.luakittens.Tuple|cpp-tools.luakittens.Dict
+---@alias cpp-tools.luakittens.PossibleOptionalType cpp-tools.luakittens.Array|cpp-tools.luakittens.Fundamental|cpp-tools.luakittens.Table|cpp-tools.luakittens.Tuple|cpp-tools.luakittens.Dict
 
----@class (exact) cpp-tools.luakittens.Type : cpp-tools.luakittens.AnyType
+---@class cpp-tools.luakittens.Type
+---@field [1] cpp-tools.luakittens.OptionalType | cpp-tools.luakittens.Nil
+
+---@class (exact) cpp-tools.luakittens.OptionalType : cpp-tools.luakittens.Type
+---@field [1] cpp-tools.luakittens.PossibleOptionalType
 ---@field opt string?
 
 ---@class (exact) cpp-tools.luakittens.Fundamental
----@field kind cpp-tools.luakittens.TypeKind.Fundamental The kind of the type
----@field type cpp-tools.luakittens.Typename The exact type, this includes all basic lua types except thread, userdata and `boolean` is changed to `bool`
+---@field kind cpp-tools.luakittens.TypeKind.Fundamental
+---@field type cpp-tools.luakittens.Typename
+---
+---@class (exact) cpp-tools.luakittens.Nil
+---@field kind cpp-tools.luakittens.TypeKind.Fundamental
+---@field type cpp-tools.luakittens.Typename.Nil
 
 ---@class (exact) cpp-tools.luakittens.Array
 ---@field kind cpp-tools.luakittens.TypeKind.Array
@@ -62,13 +69,12 @@ local Typename = {
 
 ---@class (exact) cpp-tools.luakittens.Tuple
 ---@field kind cpp-tools.luakittens.TypeKind.Tuple
----@field types cpp-tools.luakittens.TableElem[]
+---@field types cpp-tools.luakittens.Type[]
 
 ---@class (exact) cpp-tools.luakittens.Dict
 ---@field kind cpp-tools.luakittens.TypeKind.Dict
 ---@field key cpp-tools.luakittens.Type
 ---@field val cpp-tools.luakittens.Type
----@field opt string?
 
 --------------------------------------------------
 -- End Types
@@ -85,7 +91,6 @@ local Typename = {
 --- - the key-value table syntax (`table<T, U>`) is not supported, instead only the dict version exists - `{ [T]: U }`
 --- - the syntax is more restrictive, the following things are not allowed, because they're illogical:
 --- 	- `nil?` - an optional type already means `T|nil`, `nil|nil` doesn't make sense
---- 	- `T|U|T|...` - the syntax disallows specifying the same type twice ( TODO:)
 ---
 ---@param kitty cpp-tools.luakittens.Kitten a luaKITTEN definition
 ---@return boolean, string|cpp-tools.luakittens.Type[]

--- a/lua/cpp-tools/lib/luakittens/parser.lua
+++ b/lua/cpp-tools/lib/luakittens/parser.lua
@@ -175,7 +175,7 @@ local function only_parse(kitty)
 		tuple_elem <- any_type ws ','? ws
 
 		dict_type <- '{' ws dict_key ws ':' ws dict_val ws  {:kind: '}' -> 'dict' :}
-		dict_key <- {:key: '[' ws any_type ws ']' :}
+		dict_key <- {:key: '[' ws optional_type ws ']' :}
 		dict_val <- {:val: optional_type :}
 
 		table_type <- '{' ws {:fields: {| table_elem+ |} :} ws {:kind: '}' -> 'table' :}
@@ -345,6 +345,11 @@ function M.__test()
 
 		it('Nil is prohibited in dict', function()
 			assert.are.falsy(only_parse('{ [string]: nil }'))
+			assert.are.falsy(only_parse('{ [nil]: string }'))
+		end)
+
+		it('Nil is prohibited in table', function()
+			assert.are.falsy(only_parse('{ foo: nil }'))
 		end)
 
 		it('Nil is prohibited in table', function()
@@ -368,9 +373,6 @@ function M.__test()
 		end)
 	end)
 
-	-- TODO:
-	-- TODO: Make alternative work inside complex types lmao
-	-- TODO:
 	describe('`normalize()`', function()
 		it('Leaves out normal types', function()
 			local ast = parse('string')

--- a/lua/cpp-tools/lib/luakittens/parser.lua
+++ b/lua/cpp-tools/lib/luakittens/parser.lua
@@ -96,6 +96,10 @@ local function field(k, v)
 	return { key = k, val = v }
 end
 
+local function tab(...)
+	return { kind = 'table', fields = { ... } }
+end
+
 --- Adds `opt = '?'` into the type, thus marking it as optional
 ---
 ---@param type cpp-tools.luakittens.Type
@@ -340,23 +344,12 @@ function M.__test()
 
 		it('Parses tables', function()
 			assert.are.same({
-				{
-					kind = 'table',
-					fields = {
-						field('foo', fund('fn')),
-					},
-				},
+				tab(field('foo', fund('fn'))),
 			}, parse('{ foo: fn }'))
 
 			assert.are.same(
 				{
-					{
-						kind = 'table',
-						fields = {
-							field('siema n k o ', fund('fn')),
-							field('{ "siema n k o ": fn }', arr(fund('bool'))),
-						},
-					},
+					tab(field('siema n k o ', fund('fn')), field('{ "siema n k o ": fn }', arr(fund('bool')))),
 				},
 				parse([[
 				{
@@ -369,22 +362,11 @@ function M.__test()
 
 		it('Allows for trailing commas', function()
 			assert.are.same({
-				{
-					kind = 'table',
-					fields = {
-						field('a', fund('number')),
-					},
-				},
+				tab(field('a', fund('number'))),
 			}, parse('{ a: number, }'))
 
 			assert.are.same({
-				{
-					kind = 'table',
-					fields = {
-						field('a', fund('number')),
-						field('b,c,kurwa', fund('string')),
-					},
-				},
+				tab(field('a', fund('number')), field('b,c,kurwa', fund('string'))),
 			}, parse([[{ a: number, "b,c,kurwa": string  }]]))
 
 			assert.are.same({ tuple(fund('string')) }, parse('(string,)'))

--- a/lua/cpp-tools/lib/luakittens/parser.lua
+++ b/lua/cpp-tools/lib/luakittens/parser.lua
@@ -28,46 +28,6 @@ local Typename = {
 	Bool = 'bool',
 }
 
----@alias cpp-tools.luakittens.PossibleOptionalType cpp-tools.luakittens.Array|cpp-tools.luakittens.Fundamental|cpp-tools.luakittens.Table|cpp-tools.luakittens.Tuple|cpp-tools.luakittens.Dict
-
----@class cpp-tools.luakittens.Type
----@field [1] cpp-tools.luakittens.OptionalType | cpp-tools.luakittens.Nil
-
----@class (exact) cpp-tools.luakittens.OptionalType : cpp-tools.luakittens.Type
----@field [1] cpp-tools.luakittens.PossibleOptionalType
----@field opt string?
-
----@class (exact) cpp-tools.luakittens.Fundamental
----@field kind cpp-tools.luakittens.TypeKind.Fundamental
----@field type cpp-tools.luakittens.Typename
----
----@class (exact) cpp-tools.luakittens.Nil
----@field kind cpp-tools.luakittens.TypeKind.Fundamental
----@field type cpp-tools.luakittens.Typename.Nil
-
----@class (exact) cpp-tools.luakittens.Array
----@field kind cpp-tools.luakittens.TypeKind.Array
----@field type cpp-tools.luakittens.Type
-
----@class (exact) cpp-tools.luakittens.TableElem
----@field key string
----@field val cpp-tools.luakittens.Type
-
----@class (exact) cpp-tools.luakittens.Table
----@field kind cpp-tools.luakittens.TypeKind.Table
----@field fields cpp-tools.luakittens.TableElem[]
-
----@class (exact) cpp-tools.luakittens.Tuple
----@field kind cpp-tools.luakittens.TypeKind.Tuple
----@field types cpp-tools.luakittens.Type[]
-
----@class (exact) cpp-tools.luakittens.Dict
----@field kind cpp-tools.luakittens.TypeKind.Dict
----@field key cpp-tools.luakittens.Type
----@field val cpp-tools.luakittens.Type
-
----@alias cpp-tools.luakittens.Matches cpp-tools.luakittens.Type[]
-
 --------------------------------------------------
 -- End Types
 --------------------------------------------------
@@ -102,7 +62,6 @@ end
 
 --- Adds `opt = '?'` into the type, thus marking it as optional
 ---
----@param type cpp-tools.luakittens.Type
 local function make_opt(type)
 	type.opt = '?'
 	return type
@@ -116,7 +75,6 @@ end
 --- - `T|nil` -> `foo?`
 --- - `T|U|...|any` -> `any`
 ---
----@param matches cpp-tools.luakittens.Matches
 local function normalize(matches)
 	local nil_idx = nil
 	local has_nil = vim.iter(ipairs(matches)):any(function(i, m)
@@ -152,7 +110,6 @@ end
 ---In the case of two types in which one is optional and the other isn't, the one that isn't optional is removed,
 ---as `T|T?` actually means `T|T|nil`.
 ---
----@param matches cpp-tools.luakittens.Matches
 local function remove_duplicates(matches)
 	local iter = require('cpp-tools.lib.iter')
 
@@ -204,7 +161,7 @@ end
 --- 	- `nil?` - an optional type already means `T|nil`, `nil|nil` doesn't make sense
 ---
 ---@param kitty cpp-tools.luakittens.Kitten a luaKITTEN definition
----@return boolean, string|cpp-tools.luakittens.Matches
+---@return boolean, string|table
 local function only_parse(kitty)
 	local grammar = [==[
 		grammar <- ws alternative_type ws eof
@@ -255,7 +212,7 @@ local function only_parse(kitty)
 		return false, 'Cannot parse kitty\'s grammar.'
 	end
 
-	return true, matches --[=[@as cpp-tools.luakittens.Matches ]=]
+	return true, matches
 end
 
 ---Parses a type annotation with a grammar similar to that of luaCATS - luaKITTENS
@@ -271,7 +228,7 @@ end
 --- 	- `nil?` - an optional type already means `T|nil`, `nil|nil` doesn't make sense
 ---
 ---@param kitty cpp-tools.luakittens.Kitten a luaKITTEN definition
----@return boolean, string|cpp-tools.luakittens.Matches
+---@return boolean, string|table
 function M.parse(kitty)
 	local ok, matches = only_parse(kitty)
 
@@ -279,7 +236,7 @@ function M.parse(kitty)
 		return ok, matches
 	end
 
-	return ok, normalize(remove_duplicates(matches --[=[@as cpp-tools.luakittens.Matches ]=]))
+	return ok, normalize(remove_duplicates(matches))
 end
 
 ---@package


### PR DESCRIPTION
The luakittens library is an attempt to redefine the type system and type validation methods in lua.

For now the plans is for it to consist of several parts:
- the luaKITTENS annotation language, a type annotation is called `kitty` for short
- a parser for the language
- a type validator

Currently only the language and parser are done and tested, mostly. Several things are lacking for now.

There's no specification yet, to discover the language and it's capabilities one would have to look at the `only_parse` function and `__test()` -> `describe('`only_parse()`)`

---

This implementation is incomplete and I will be rewriting it to a handwritten parser, which will allow for more fine-grained syntax control and better diagnostics.