### PR TITLE
test: add testfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@
 !ftplugin/
 !*.rockspec
 
+# Testing
+!testfiles/
+
 # Plugin test & lint
 !.busted
 !.luacheckrc

--- a/docs/spec/0.1/technical.md
+++ b/docs/spec/0.1/technical.md
@@ -1,0 +1,17 @@
+# Technical spec of cpp-tools.nvim
+
+## Automatic test runner
+
+Each module (lua module, not cpp-tools module) can define its tests by exposing a `__test` function.
+The function should contain ordinary busted tests.
+
+This approach is chosen because it's much easier to test the implementation that way.
+And while some people argue that it's inelegant and instead only the public interface should be tested,
+I found that this approach gives me more flexibility and provides faster feedback while implementing solutions.
+
+The automatic test runner is a file called `auto_test_runner.lua` inside the root `lua` directory.
+It's called by busted (see `<root>/.busted`'s `_all.pattern` key) and receives it's context
+(global functions for testing + monkey patched assert).
+
+It then scans all lua files in `lua`, evaluates them and collects all that returned a table with the `__test` key,
+then calls each of the test functions with the context.

--- a/lua/cpp-tools/auto_test_runner.lua
+++ b/lua/cpp-tools/auto_test_runner.lua
@@ -3,6 +3,7 @@
 --- and runs their __test functions with busted test context.
 
 local current_filename = debug.getinfo(1).source:match('([%w_%.]+)$')
+local testfiles_dir = vim.fs.root(0, '.git') .. '/testfiles'
 
 local function project_lua_files(path, type)
 	return type == 'file' and vim.endswith(path, 'lua') and not vim.endswith(path, current_filename)
@@ -30,7 +31,7 @@ local function run_module_test(name)
 
 	local test_func = vim.tbl_get(module, '__test')
 	if test_func then
-		setfenv(test_func, getfenv())()
+		setfenv(test_func, getfenv())(testfiles_dir)
 	end
 end
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -37,6 +37,7 @@
         fs.toSource {
           inherit root;
           fileset = fs.unions [
+            (root + /testfiles)
             (root + /ftplugin)
             (root + /lua)
             (root + /.busted)

--- a/testfiles/README.md
+++ b/testfiles/README.md
@@ -1,0 +1,5 @@
+# Testfiles
+
+A special directory with all kinds of test files categorized by modules that use them in their tests.
+
+Tests use these files by requiring them like so: `require('testfiles.lib.modules')`, `require('testfiles.modules.foo')`, etc.


### PR DESCRIPTION
The `testfiles/` directory will contain files which tests use. The files are categorized by their type (`lib`/`modules`) and specific lib/module, e.g. `testfiles/lib/modules`, `testfiles/modules/preamble`.

It can both contain some kind of executable files as well as simple text files for testing. For that to work, each `__test` function now receives an argument which is the absolute path to the `testfiles` directory.